### PR TITLE
fix issue when requesting image : image was smaller than original

### DIFF
--- a/BRNImagePickerSheet/BRNImagePickerSheet.swift
+++ b/BRNImagePickerSheet/BRNImagePickerSheet.swift
@@ -394,13 +394,19 @@ public class BRNImagePickerSheet: UIView, UITableViewDataSource, UITableViewDele
         self.imageManager.startCachingImagesForAssets([asset], targetSize: targetSize, contentMode: .AspectFit, options: nil)
     }
     
+    private func requestOriginalImageForAsset(asset: PHAsset, completion: (image: UIImage) -> Void) {
+        self.imageManager.requestImageForAsset(asset, targetSize: PHImageManagerMaximumSize, contentMode: .AspectFit, options: nil) { (image, _) -> Void in
+            completion(image: image)
+        }
+    }
+    
     public func getSelectedImagesWithCompletion(completion: (images:[UIImage]) -> Void) {
         var images = [UIImage]()
         var counter = self.selectedPhotoIndices.count
         
         for index in self.selectedPhotoIndices {
             let asset = self.assets[index]
-            self.requestImageForAsset(asset, size: PHImageManagerMaximumSize, completion: { (image) -> Void in
+            self.requestOriginalImageForAsset(asset, completion: { (image) -> Void in
                 images.append(image)
                 counter--
                 


### PR DESCRIPTION
@larcus94 

The method getSelectedImagesWithCompletion was returning small images instead of the original sized images.
I fixed it by adding a method that use PHImageManagerMaximumSize to request the image and by not use         

  let targetSize = self.targetSizeForAssetOfSize(size)


